### PR TITLE
Fix #10 - Use authorization http header

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME     := prnotify
-VERSION  := 0.9.0
+VERSION  := 0.10.0
 REVISION := $(shell git rev-parse --short HEAD)
 SRCS     := $(shell find . -type f -name '*.go')
 LDFLAGS  := -ldflags="-X \"main.Version=$(VERSION)\" -X \"main.Revision=$(REVISION)\""

--- a/github.go
+++ b/github.go
@@ -1,5 +1,9 @@
 package main
 
+import (
+	"fmt"
+)
+
 type GitHubAPI struct {
 	AccessToken string
 	Owner       string
@@ -15,5 +19,5 @@ func NewGitHubAPI(config Config) GitHubAPI {
 }
 
 func (gh GitHubAPI) BaseURL() string {
-	return "https://api.github.com/repos/" + gh.Owner + "/" + gh.Repo
+	return fmt.Sprintf("https://api.github.com/repos/%s/%s", gh.Owner, gh.Repo)
 }

--- a/pulls.go
+++ b/pulls.go
@@ -41,14 +41,9 @@ func (gh GitHubAPI) GetPulls() ([]PullRequest, error) {
 	var pulls []PullRequest
 
 	// Prepare HTTP Request
-	url := gh.BaseURL() + "/pulls" + "?access_token=" + gh.AccessToken
+	url := fmt.Sprintf("%s/pulls", gh.BaseURL())
 	req, err := http.NewRequest("GET", url, nil)
-
-	parseFormErr := req.ParseForm()
-	if parseFormErr != nil {
-		fmt.Fprintln(os.Stderr, "GitHubAPI - PullRequest: <error> parse http request form:", parseFormErr)
-		return pulls, parseFormErr
-	}
+	req.Header.Add("Authorization", fmt.Sprintf("token %s", gh.AccessToken))
 
 	// Fetch Request
 	client := &http.Client{}

--- a/reviews.go
+++ b/reviews.go
@@ -23,18 +23,12 @@ func (gh GitHubAPI) GetReviewsWithPullRequest(pull PullRequest) ([]Review, error
 	var reviews []Review
 
 	// Prepare HTTP Request
-	num := fmt.Sprintf("%d", pull.Number)
-	url := gh.BaseURL() + "/pulls/" + num + "/reviews" + "?access_token=" + gh.AccessToken
+	url := fmt.Sprintf("%s/pulls/%d/reviews", gh.BaseURL(), pull.Number)
 	req, err := http.NewRequest("GET", url, nil)
 
 	// Headers
 	req.Header.Add("Accept", "application/vnd.github.black-cat-preview+json")
-
-	parseFormErr := req.ParseForm()
-	if parseFormErr != nil {
-		fmt.Fprintln(os.Stderr, "GitHubAPI - Reviews: <error> parse http request form:", parseFormErr)
-		return reviews, parseFormErr
-	}
+	req.Header.Add("Authorization", fmt.Sprintf("token %s", gh.AccessToken))
 
 	// Fetch Request
 	client := &http.Client{}


### PR DESCRIPTION
- Fix #10
- Use authorization http header instead of query parameter
- :up: v0.10.0

> Please use the Authorization HTTP header instead, as using the `access_token` query parameter is deprecated.

https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/#3-use-the-access-token-to-access-the-api

> Authorization: token OAUTH-TOKEN
> GET https://api.github.com/user